### PR TITLE
disabled devise sign in for studios index and show

### DIFF
--- a/app/controllers/studios_controller.rb
+++ b/app/controllers/studios_controller.rb
@@ -1,5 +1,5 @@
 class StudiosController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:show, :create]
+  skip_before_action :authenticate_user!, only: [:index, :show]
 
   def index
     # binding.pry


### PR DESCRIPTION
users now don't need to log in to see index or show pages 